### PR TITLE
Add livox_sdk2 to driver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/livox_sdk2"]
+	path = src/livox_sdk2
+	url = git@github.com:enwaytech/Livox-SDK2.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,8 +88,11 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-## make sure the livox_lidar_sdk_static library is installed
-find_library(LIVOX_LIDAR_SDK_LIBRARY  liblivox_lidar_sdk_static.a    /usr/local/lib)
+#---------------------------------------------------------------------------------------
+# livox_sdk2
+#---------------------------------------------------------------------------------------
+add_subdirectory(src/livox_sdk2)
+find_package(livox_sdk2 REQUIRED)
 
 ## PCL library
 link_directories(${PCL_LIBRARY_DIRS})


### PR DESCRIPTION
This PR adds the Livox-SDK2 as a submodule to the driver.

Test together with PR #4203 in main repo.