### PR TITLE
Fix sparse publishing of pointcloud bug by adding a check for time jump and setting it to now

### DIFF
--- a/src/comm/pub_handler.cpp
+++ b/src/comm/pub_handler.cpp
@@ -30,6 +30,10 @@
 #include <limits>
 namespace livox_ros {
 
+PubHandler::PubHandler() {
+  time_is_steady_ = std::chrono::high_resolution_clock::is_steady;
+}
+
 PubHandler &pub_handler() {
   static PubHandler handler;
   return handler;
@@ -201,6 +205,13 @@ void PubHandler::CheckTimer() {
     return;
   }
   last_pub_time_ += std::chrono::nanoseconds(publish_interval_);
+
+  if (!time_is_steady_) {
+    if (now_time - last_pub_time_ > std::chrono::nanoseconds(publish_interval_)) {
+      std::cerr << "Detected a jump in time, setting last pub time to now" << std::endl;
+      last_pub_time_ = now_time;
+    }
+  }
 
   PublishPointCloud();
 

--- a/src/comm/pub_handler.h
+++ b/src/comm/pub_handler.h
@@ -90,7 +90,7 @@ class PubHandler {
   using ImuDataCallback = std::function<void(ImuData*, void*)>;
   using TimePoint = std::chrono::high_resolution_clock::time_point;
 
-  PubHandler() {}
+  PubHandler();
 
   ~ PubHandler() { Uninit(); }
 
@@ -145,6 +145,7 @@ class PubHandler {
   std::map<uint32_t, LidarFilterParameter> lidar_filters_;
 
   uint16_t lidar_listen_id_ = 0;
+  bool time_is_steady_ = false;
 };
 
 PubHandler &pub_handler();


### PR DESCRIPTION
Test together with PR in main repo.

To reproduce the problem:
```
- disable chrony with systemctl disable chronyd
- reboot
- date should be at around "Mo 27. Mär 19:54:39 CEST 2023"
- launch software
- start visualization on point clouds
- sudo chronyd
- after the date was synced, the point clouds are incomplete, flickering and published with a super high frequency
```