### PR TITLE
Add publisher for non-return rays

### DIFF
--- a/include/livox_ros_driver2/livox_point.h
+++ b/include/livox_ros_driver2/livox_point.h
@@ -45,6 +45,7 @@ typedef struct {
   float range;        /**< Range Unit:m */
   float thetha;       /**< Theta angle [rad]*/
   float phi;          /**< Phi angle [rad]*/
+  uint8_t tag;
 } LivoxPointRtp;
 #pragma pack()
 

--- a/include/livox_ros_driver2/livox_point.h
+++ b/include/livox_ros_driver2/livox_point.h
@@ -38,7 +38,14 @@ typedef struct {
   uint8_t line;       /**< Laser line id     */
   double timestamp;   /**< Timestamp of point*/
 } LivoxPointXyzrtlt;
-
+typedef struct {
+  float x;
+  float y;
+  float z;
+  float range;        /**< Range Unit:m */
+  float thetha;       /**< Theta angle [rad]*/
+  float phi;          /**< Phi angle [rad]*/
+} LivoxPointRtp;
 #pragma pack()
 
 }

--- a/include/livox_ros_driver2/livox_point.h
+++ b/include/livox_ros_driver2/livox_point.h
@@ -46,6 +46,7 @@ typedef struct {
   float thetha;       /**< Theta angle [rad]*/
   float phi;          /**< Phi angle [rad]*/
   uint8_t tag;
+  float intensity;
 } LivoxPointRtp;
 #pragma pack()
 

--- a/src/comm/comm.h
+++ b/src/comm/comm.h
@@ -248,12 +248,26 @@ typedef struct {
 } FilterParameter;
 
 typedef struct {
+  std::string filter_rays_frame_id;  /**< Frame */
+  float filter_rays_yaw_start; /**< Start yaw angle, unit: degree. */
+  float filter_rays_yaw_end; /**< End yaw angle, unit: degree. */
+  float filter_rays_pitch_start; /**< Start pitch angle, unit: degree. */
+  float filter_rays_pitch_end;  /**< End pitch angle, unit: degree. */
+} FilterRaysParameter;
+
+typedef struct {
   LidarProtoType lidar_type;
   uint32_t handle;
   FilterTransformParameter transform;
   FilterParameter param;
 } LidarFilterParameter;
 
+typedef struct {
+  LidarProtoType lidar_type;
+  uint32_t handle;
+  FilterTransformParameter transform;
+  FilterRaysParameter rays_param;
+} LidarFilterRaysParameter;
 
 /** Configuration in json config file for livox lidar */
 typedef struct {
@@ -287,7 +301,9 @@ typedef struct {
   std::string frame_id;
   ExtParameter extrinsic_param;
   bool enable_yaw_filter;
+  bool enable_rays_filter;
   FilterParameter filter_param;
+  FilterRaysParameter filter_rays_param;
   volatile uint32_t set_bits;
   volatile uint32_t get_bits;
 } UserLivoxLidarConfig;

--- a/src/comm/comm.h
+++ b/src/comm/comm.h
@@ -162,12 +162,6 @@ typedef struct {
 } PointXyzltrtp;
 
 typedef struct {
-  float range;
-  float theta;
-  float phi;
-} PointRtp;
-
-typedef struct {
   uint32_t handle;
   uint8_t lidar_type; ////refer to LivoxLidarType
   uint32_t points_num;

--- a/src/comm/comm.h
+++ b/src/comm/comm.h
@@ -156,13 +156,22 @@ typedef struct {
   uint8_t tag;
   uint8_t line;
   uint64_t offset_time;
-} PointXyzlt;
+  float range;
+  float theta;
+  float phi;
+} PointXyzltrtp;
+
+typedef struct {
+  float range;
+  float theta;
+  float phi;
+} PointRtp;
 
 typedef struct {
   uint32_t handle;
   uint8_t lidar_type; ////refer to LivoxLidarType
   uint32_t points_num;
-  PointXyzlt* points;
+  PointXyzltrtp* points;
 } PointPacket;
 
 typedef struct {
@@ -178,7 +187,7 @@ typedef struct {
   uint32_t handle;
   uint64_t base_time;
   uint32_t points_num;
-  std::vector<PointXyzlt> points;
+  std::vector<PointXyzltrtp> points;
 } StoragePacket;
 
 typedef struct {

--- a/src/comm/comm.h
+++ b/src/comm/comm.h
@@ -253,6 +253,9 @@ typedef struct {
   float filter_rays_yaw_end; /**< End yaw angle, unit: degree. */
   float filter_rays_pitch_start; /**< Start pitch angle, unit: degree. */
   float filter_rays_pitch_end;  /**< End pitch angle, unit: degree. */
+  bool filter_rays_local_theta; /**< Use local theta filter or not. */
+  float filter_rays_local_theta_start; /**< Start local theta angle, unit: degree. */
+  float filter_rays_local_theta_end; /**< End local theta angle, unit: degree. */
 } FilterRaysParameter;
 
 typedef struct {

--- a/src/comm/ldq.cpp
+++ b/src/comm/ldq.cpp
@@ -100,7 +100,7 @@ bool QueuePrePop(LidarDataQueue *queue, StoragePacket *storage_packet) {
   storage_packet->points_num = queue->storage_packet[rd_idx].points_num;
   storage_packet->points.resize(queue->storage_packet[rd_idx].points_num);
 
-  memcpy(storage_packet->points.data(), queue->storage_packet[rd_idx].points.data(), (storage_packet->points_num) * sizeof(PointXyzlt));
+  memcpy(storage_packet->points.data(), queue->storage_packet[rd_idx].points.data(), (storage_packet->points_num) * sizeof(PointXyzltrtp));
   return true;
 }
 
@@ -141,7 +141,7 @@ uint32_t QueuePushAny(LidarDataQueue *queue, uint8_t *data, const uint64_t base_
 
   queue->storage_packet[wr_idx].points.clear();
   queue->storage_packet[wr_idx].points.resize(lidar_point_data->points_num);
-  memcpy(queue->storage_packet[wr_idx].points.data(), lidar_point_data->points, sizeof(PointXyzlt) * (lidar_point_data->points_num));
+  memcpy(queue->storage_packet[wr_idx].points.data(), lidar_point_data->points, sizeof(PointXyzltrtp) * (lidar_point_data->points_num));
 
   queue->wr_idx++;
   return 1;

--- a/src/comm/pub_handler.cpp
+++ b/src/comm/pub_handler.cpp
@@ -670,7 +670,14 @@ bool LidarPubHandler::FilterRay(const PointXyzltrtp& point)
   }
 
   double pitch = std::asin(base_point.z / std::sqrt(base_point.x * base_point.x + base_point.y * base_point.y + base_point.z * base_point.z));
-  if (pitch >= filter_rays_pitch_start_ && pitch <= filter_rays_pitch_end_)
+  if (filter_rays_pitch_end_ >= filter_rays_pitch_start_)
+  {
+    if (pitch >= filter_rays_pitch_start_ && pitch <= filter_rays_pitch_end_)
+    {
+      return true;
+    }
+  }
+  else if (pitch < filter_rays_pitch_end_ || pitch > filter_rays_pitch_start_)
   {
     return true;
   }

--- a/src/comm/pub_handler.cpp
+++ b/src/comm/pub_handler.cpp
@@ -98,7 +98,7 @@ void PubHandler::AddLidarsFilterParam(LidarFilterParameter& filter_param) {
 
 void PubHandler::ClearAllLidarsFilterParams() {
   std::unique_lock<std::mutex> lock(packet_mutex_);
-  lidar_rays_filters_.clear();
+  lidar_filters_.clear();
 }
 
 void PubHandler::AddLidarsFilterRaysParam(LidarFilterRaysParameter& filter_rays_param) {

--- a/src/comm/pub_handler.cpp
+++ b/src/comm/pub_handler.cpp
@@ -452,6 +452,14 @@ void LidarPubHandler::SetLidarsFilterRaysParam(LidarFilterRaysParameter param) {
   filter_rays_yaw_end_ = param.rays_param.filter_rays_yaw_end * PI / 180.0;
   filter_rays_pitch_start_ = param.rays_param.filter_rays_pitch_start * PI / 180.0;
   filter_rays_pitch_end_ = param.rays_param.filter_rays_pitch_end * PI / 180.0;
+  if (param.rays_param.filter_rays_local_theta)
+  {
+    filter_rays_local_theta_ = true;
+    filter_rays_local_theta_start_ = param.rays_param.filter_rays_local_theta_start * PI / 180.0;
+    filter_rays_local_theta_end_ = param.rays_param.filter_rays_local_theta_end * PI / 180.0;
+  }
+
+
   is_set_filter_rays_params_ = true;
 }
 
@@ -557,8 +565,12 @@ void LidarPubHandler::ProcessSphericalPoint(RawPacket& pkt) {
       ray_no_return.x = sin(theta) * cos(phi);
       ray_no_return.y = sin(theta) * sin(phi);
       ray_no_return.z = cos(theta);
-      //ray_no_return.theta = theta;
-      //ray_no_return.phi = phi;
+
+      if (is_set_filter_rays_params_ && filter_rays_local_theta_ && theta > filter_rays_local_theta_start_ && theta < filter_rays_local_theta_end_)
+      {
+        continue;
+      }
+
       if (FilterRay(ray_no_return))
       {
         continue;

--- a/src/comm/pub_handler.cpp
+++ b/src/comm/pub_handler.cpp
@@ -533,17 +533,16 @@ void LidarPubHandler::ProcessSphericalPoint(RawPacket& pkt) {
 
     std::lock_guard<std::mutex> lock(mutex_);
     points_clouds_.push_back(point);
-  /*
-    if (radius == 0.0f)
+
+    /*if (radius == 0.0f)
     {
       PointRtp invalid_point = {};
       invalid_point.range = radius;
       invalid_point.theta = theta;
       invalid_point.phi = phi;
       //invalid_point.offset_time = pkt.time_stamp + i * pkt.point_interval;
-      //points_invalid_clouds_.push_back(invalid_point);
-    }
-*/
+      points_invalid_clouds_.push_back(invalid_point);
+    }*/
   }
 }
 

--- a/src/comm/pub_handler.cpp
+++ b/src/comm/pub_handler.cpp
@@ -458,8 +458,10 @@ void LidarPubHandler::SetLidarsFilterRaysParam(LidarFilterRaysParameter param) {
     filter_rays_local_theta_start_ = param.rays_param.filter_rays_local_theta_start * PI / 180.0;
     filter_rays_local_theta_end_ = param.rays_param.filter_rays_local_theta_end * PI / 180.0;
   }
-
-
+  else
+  {
+    filter_rays_local_theta_ = false;
+  }
   is_set_filter_rays_params_ = true;
 }
 
@@ -559,7 +561,7 @@ void LidarPubHandler::ProcessSphericalPoint(RawPacket& pkt) {
                 src_z * extrinsic_.rotation[2][2] + (extrinsic_.trans[2] / 1000.0);
     }
 
-    if (radius == 0.0f) // Ray with no return
+    if (raw[i].depth == 0U) // Ray with no return
     {
       PointXyzltrtp ray_no_return;
       ray_no_return.x = sin(theta) * cos(phi);

--- a/src/comm/pub_handler.h
+++ b/src/comm/pub_handler.h
@@ -80,14 +80,21 @@ class LidarPubHandler {
 
   float filter_yaw_start_;
   float filter_yaw_end_;
-  std::mutex mutex_;
-  std::atomic_bool is_set_extrinsic_params_;
-  std::atomic_bool is_set_filter_params_;
+
+  RotationMatrix filter_rays_rotation_ = {
+      {1, 0, 0},
+      {0, 1, 0},
+      {0, 0, 1}
+  };
 
   float filter_rays_yaw_start_;
   float filter_rays_yaw_end_;
   float filter_rays_pitch_start_;
   float filter_rays_pitch_end_;
+
+  std::mutex mutex_;
+  std::atomic_bool is_set_extrinsic_params_;
+  std::atomic_bool is_set_filter_params_;
   std::atomic_bool is_set_filter_rays_params_;
 };
   

--- a/src/comm/pub_handler.h
+++ b/src/comm/pub_handler.h
@@ -162,7 +162,6 @@ class PubHandler {
 
   std::map<uint32_t, std::unique_ptr<LidarPubHandler>> lidar_process_handlers_;
   std::map<uint32_t, std::vector<PointXyzltrtp>> points_;
-  std::map<uint32_t, std::vector<PointRtp>> non_return_rays_;
   std::map<uint32_t, LidarExtParameter> lidar_extrinsics_;
   std::map<uint32_t, LidarFilterParameter> lidar_filters_;
   std::map<uint32_t, LidarFilterRaysParameter> lidar_rays_filters_;

--- a/src/comm/pub_handler.h
+++ b/src/comm/pub_handler.h
@@ -63,6 +63,7 @@ class LidarPubHandler {
   void ProcessSphericalPoint(RawPacket & pkt);
   bool FilterYawPoint(const PointXyzltrtp& point);
   bool FilterRay(const PointXyzltrtp& point);
+
   std::vector<PointXyzltrtp> points_clouds_;
   ExtParameterDetailed extrinsic_ = {
     {0, 0, 0},
@@ -91,7 +92,9 @@ class LidarPubHandler {
   float filter_rays_yaw_end_;
   float filter_rays_pitch_start_;
   float filter_rays_pitch_end_;
-
+  bool filter_rays_local_theta_;
+  float filter_rays_local_theta_start_;
+  float filter_rays_local_theta_end_;
   std::mutex mutex_;
   std::atomic_bool is_set_extrinsic_params_;
   std::atomic_bool is_set_filter_params_;

--- a/src/comm/pub_handler.h
+++ b/src/comm/pub_handler.h
@@ -49,6 +49,7 @@ class LidarPubHandler {
   void PointCloudProcess(RawPacket& pkt);
   void SetLidarsExtParam(LidarExtParameter param);
   void SetLidarsFilterParam(LidarFilterParameter param);
+  void SetLidarsFilterRaysParam(LidarFilterRaysParameter param);
   void GetLidarPointClouds(std::vector<PointXyzltrtp>& points_clouds);
 
   uint64_t GetRecentTimeStamp();
@@ -61,6 +62,7 @@ class LidarPubHandler {
   void ProcessCartesianLowPoint(RawPacket & pkt);
   void ProcessSphericalPoint(RawPacket & pkt);
   bool FilterYawPoint(const PointXyzltrtp& point);
+  bool FilterRay(const PointXyzltrtp& point);
   std::vector<PointXyzltrtp> points_clouds_;
   ExtParameterDetailed extrinsic_ = {
     {0, 0, 0},
@@ -81,6 +83,12 @@ class LidarPubHandler {
   std::mutex mutex_;
   std::atomic_bool is_set_extrinsic_params_;
   std::atomic_bool is_set_filter_params_;
+
+  float filter_rays_yaw_start_;
+  float filter_rays_yaw_end_;
+  float filter_rays_pitch_start_;
+  float filter_rays_pitch_end_;
+  std::atomic_bool is_set_filter_rays_params_;
 };
   
 class PubHandler {
@@ -103,6 +111,9 @@ class PubHandler {
 
   void AddLidarsFilterParam(LidarFilterParameter& filter_param);
   void ClearAllLidarsFilterParams();
+
+  void AddLidarsFilterRaysParam(LidarFilterRaysParameter& filter_rays_param);
+  void ClearAllLidarsFilterRaysParams();
 
   void SetImuDataCallback(ImuDataCallback cb, void* client_data);
 
@@ -144,6 +155,7 @@ class PubHandler {
   std::map<uint32_t, std::vector<PointRtp>> invalid_points_;
   std::map<uint32_t, LidarExtParameter> lidar_extrinsics_;
   std::map<uint32_t, LidarFilterParameter> lidar_filters_;
+  std::map<uint32_t, LidarFilterRaysParameter> lidar_rays_filters_;
   static std::atomic<bool> is_timestamp_sync_;
   uint16_t lidar_listen_id_ = 0;
 };

--- a/src/comm/pub_handler.h
+++ b/src/comm/pub_handler.h
@@ -159,7 +159,7 @@ class PubHandler {
 
   std::map<uint32_t, std::unique_ptr<LidarPubHandler>> lidar_process_handlers_;
   std::map<uint32_t, std::vector<PointXyzltrtp>> points_;
-  std::map<uint32_t, std::vector<PointRtp>> invalid_points_;
+  std::map<uint32_t, std::vector<PointRtp>> non_return_rays_;
   std::map<uint32_t, LidarExtParameter> lidar_extrinsics_;
   std::map<uint32_t, LidarFilterParameter> lidar_filters_;
   std::map<uint32_t, LidarFilterRaysParameter> lidar_rays_filters_;

--- a/src/comm/pub_handler.h
+++ b/src/comm/pub_handler.h
@@ -49,7 +49,7 @@ class LidarPubHandler {
   void PointCloudProcess(RawPacket& pkt);
   void SetLidarsExtParam(LidarExtParameter param);
   void SetLidarsFilterParam(LidarFilterParameter param);
-  void GetLidarPointClouds(std::vector<PointXyzlt>& points_clouds);
+  void GetLidarPointClouds(std::vector<PointXyzltrtp>& points_clouds);
 
   uint64_t GetRecentTimeStamp();
   uint32_t GetLidarPointCloudsSize();
@@ -60,8 +60,8 @@ class LidarPubHandler {
   void ProcessCartesianHighPoint(RawPacket & pkt);
   void ProcessCartesianLowPoint(RawPacket & pkt);
   void ProcessSphericalPoint(RawPacket & pkt);
-  bool FilterYawPoint(const PointXyzlt& point);
-  std::vector<PointXyzlt> points_clouds_;
+  bool FilterYawPoint(const PointXyzltrtp& point);
+  std::vector<PointXyzltrtp> points_clouds_;
   ExtParameterDetailed extrinsic_ = {
     {0, 0, 0},
     {
@@ -140,7 +140,8 @@ class PubHandler {
   TimePoint last_pub_time_;
 
   std::map<uint32_t, std::unique_ptr<LidarPubHandler>> lidar_process_handlers_;
-  std::map<uint32_t, std::vector<PointXyzlt>> points_;
+  std::map<uint32_t, std::vector<PointXyzltrtp>> points_;
+  std::map<uint32_t, std::vector<PointRtp>> invalid_points_;
   std::map<uint32_t, LidarExtParameter> lidar_extrinsics_;
   std::map<uint32_t, LidarFilterParameter> lidar_filters_;
   static std::atomic<bool> is_timestamp_sync_;

--- a/src/lddc.cpp
+++ b/src/lddc.cpp
@@ -499,6 +499,7 @@ void Lddc::InitPointcloud2InvalidPointsMsg(const StoragePacket& pkg, PointCloud2
       point.thetha = pkg.points[i].theta;
       point.phi = pkg.points[i].phi;
       point.tag = pkg.points[i].tag;
+      point.intensity = pkg.points[i].intensity;
       points.push_back(std::move(point));
     }
   }
@@ -513,7 +514,7 @@ void Lddc::InitPointcloud2InvalidPointsMsgHeader(PointCloud2& cloud, const std::
   cloud.header.frame_id.assign(frame_id);
   cloud.height = 1;
   cloud.width = 0;
-  cloud.fields.resize(7);
+  cloud.fields.resize(8);
   cloud.fields[0].offset = 0;
   cloud.fields[0].name = "x";
   cloud.fields[0].count = 1;
@@ -542,6 +543,10 @@ void Lddc::InitPointcloud2InvalidPointsMsgHeader(PointCloud2& cloud, const std::
   cloud.fields[6].name = "tag";
   cloud.fields[6].count = 1;
   cloud.fields[6].datatype = PointField::UINT8;
+  cloud.fields[7].offset = 25;
+  cloud.fields[7].name = "intensity";
+  cloud.fields[7].count = 1;
+  cloud.fields[7].datatype = PointField::FLOAT32;
   cloud.point_step = sizeof(LivoxPointRtp);
 }
 

--- a/src/lddc.cpp
+++ b/src/lddc.cpp
@@ -480,30 +480,30 @@ void Lddc::InitPointcloud2NonReturnRaysMsg(const StoragePacket& pkg, PointCloud2
       cloud.header.stamp = rclcpp::Time(timestamp);
   #endif
 
-  std::vector<LivoxPointRtp> points;
+  std::vector<LivoxPointRtp> rays;
   size_t i {0};
   for (i = 0; i < pkg.points_num; ++i) {
     if (pkg.points[i].range == 0.0)
     {
-      LivoxPointRtp point; // x y z now only for debugging set to 1m for debugging
+      LivoxPointRtp ray;
       double src_x = sin(pkg.points[i].theta) * cos(pkg.points[i].phi);
       double src_y = sin(pkg.points[i].theta) * sin(pkg.points[i].phi);
       double src_z = cos(pkg.points[i].theta);
-      point.x = src_x;
-      point.y = src_y;
-      point.z = src_z;
-      point.range = pkg.points[i].range;
-      point.thetha = pkg.points[i].theta;
-      point.phi = pkg.points[i].phi;
-      point.tag = pkg.points[i].tag;
-      point.intensity = pkg.points[i].intensity;
-      points.push_back(std::move(point));
+      ray.x = src_x;
+      ray.y = src_y;
+      ray.z = src_z;
+      ray.range = pkg.points[i].range;
+      ray.thetha = pkg.points[i].theta;
+      ray.phi = pkg.points[i].phi;
+      ray.tag = pkg.points[i].tag;
+      ray.intensity = pkg.points[i].intensity;
+      rays.push_back(std::move(ray));
     }
   }
-  cloud.width = points.size();
+  cloud.width = rays.size();
   cloud.row_step = cloud.width * cloud.point_step;
-  cloud.data.resize(points.size() * sizeof(LivoxPointRtp));
-  memcpy(cloud.data.data(), points.data(), points.size() * sizeof(LivoxPointRtp));
+  cloud.data.resize(rays.size() * sizeof(LivoxPointRtp));
+  memcpy(cloud.data.data(), rays.data(), rays.size() * sizeof(LivoxPointRtp));
 }
 
 void Lddc::InitPointcloud2NonReturnRaysMsgHeader(PointCloud2& cloud, const std::string& frame_id) {
@@ -625,7 +625,6 @@ void Lddc::FillPointsToCustomMsg(CustomMsg& livox_msg, const StoragePacket& pkg)
     point.reflectivity = points[i].intensity;
     point.tag = points[i].tag;
     point.line = points[i].line;
-    //point.range = sqrt(points[i].x * points[i].x + points[i].y * points[i].y + points[i].z * points[i].z);
     point.offset_time = static_cast<uint32_t>(points[i].offset_time - pkg.base_time);
 
     livox_msg.points.push_back(std::move(point));

--- a/src/lddc.cpp
+++ b/src/lddc.cpp
@@ -48,7 +48,7 @@ namespace livox_ros
 #ifdef BUILDING_ROS1
 Lddc::Lddc(int format, int multi_topic, int data_src, int output_type, double frq, std::string &frame_id,
            const std::vector<double>& angular_velocity_covariance,
-           const std::vector<double>& linear_acceleration_covariance, bool lidar_bag, bool imu_bag, bool dust_filter)
+           const std::vector<double>& linear_acceleration_covariance, bool lidar_bag, bool imu_bag, bool dust_filter, bool pub_invalid_points)
     : transfer_format_(format),
       use_multi_topic_(multi_topic),
       data_src_(data_src),
@@ -58,13 +58,16 @@ Lddc::Lddc(int format, int multi_topic, int data_src, int output_type, double fr
       angular_velocity_covariance_(angular_velocity_covariance),
       linear_acceleration_covariance_(linear_acceleration_covariance),
       enable_lidar_bag_(lidar_bag),
-      enable_imu_bag_(imu_bag) {
+      enable_imu_bag_(imu_bag),
+      pub_invalid_points_(pub_invalid_points) {
   publish_period_ns_ = kNsPerSecond / publish_frq_;
   lds_ = nullptr;
   memset(private_pub_, 0, sizeof(private_pub_));
   memset(private_imu_pub_, 0, sizeof(private_imu_pub_));
+  memset(private_invalid_points_pub_, 0, sizeof(private_invalid_points_pub_));
   global_pub_ = nullptr;
   global_imu_pub_ = nullptr;
+  global_invalid_points_pub_ = nullptr;
   cur_node_ = nullptr;
   bag_ = nullptr;
 
@@ -292,6 +295,16 @@ void Lddc::PublishPointcloud2(LidarDataQueue *queue, uint8_t index, const std::s
       InitPointcloud2Msg(pkg, cloud, timestamp, frame_id);
     }
     PublishPointcloud2Data(index, timestamp, cloud);
+
+    if (pub_invalid_points_ || true)
+    {
+      sensor_msgs::PointCloud2 invalid_points_cloud;
+      //printf("Publish invalid points.\n");
+      printf("Points in pkg: %u", pkg.points.size());
+      InitPointcloud2InvalidPointsMsg(pkg, invalid_points_cloud, timestamp, frame_id);
+      PublishPointcloud2InvalidPointsData(index, timestamp, invalid_points_cloud);  
+    }
+
   }
 }
 
@@ -452,6 +465,100 @@ void Lddc::InitPointcloud2Msg(const StoragePacket& pkg, PointCloud2& cloud, uint
   memcpy(cloud.data.data(), points.data(), pkg.points_num * sizeof(LivoxPointXyzrtlt));
 }
 
+void Lddc::InitPointcloud2InvalidPointsMsg(const StoragePacket& pkg, PointCloud2& cloud, uint64_t& timestamp, const std::string& frame_id) {
+  InitPointcloud2InvalidPointsMsgHeader(cloud, frame_id);
+
+  cloud.point_step = sizeof(LivoxPointRtp);
+
+  cloud.is_bigendian = false;
+  cloud.is_dense     = true;
+
+  if (!pkg.points.empty()) {
+    timestamp = pkg.base_time;
+  }
+
+  #ifdef BUILDING_ROS1
+      cloud.header.stamp = ros::Time( timestamp / 1000000000.0);
+  #elif defined BUILDING_ROS2
+      cloud.header.stamp = rclcpp::Time(timestamp);
+  #endif
+
+  std::vector<LivoxPointRtp> points;
+  size_t i {0};
+  for (i = 0; i < pkg.points_num; ++i) {
+    if (pkg.points[i].range == 0.0)
+    {
+      LivoxPointRtp point; // x y z now only for debugging set to 1m for debugging
+      double src_x = sin(pkg.points[i].theta) * cos(pkg.points[i].phi);
+      double src_y = sin(pkg.points[i].theta) * sin(pkg.points[i].phi);
+      double src_z = cos(pkg.points[i].theta);
+      point.x = src_x; //pkg.points[i].x;
+      point.y = src_y; //pkg.points[i].y;
+      point.z = src_z; //pkg.points[i].z;
+      point.range = pkg.points[i].range;
+      point.thetha = pkg.points[i].theta;
+      point.phi = pkg.points[i].phi;
+      points.push_back(std::move(point));
+    }
+  }
+  printf("Points %u\n", points.size());
+  cloud.width = points.size();
+  cloud.row_step = cloud.width * cloud.point_step;
+  cloud.data.resize(points.size() * sizeof(LivoxPointRtp));
+  memcpy(cloud.data.data(), points.data(), points.size() * sizeof(LivoxPointRtp));
+}
+
+void Lddc::InitPointcloud2InvalidPointsMsgHeader(PointCloud2& cloud, const std::string& frame_id) {
+  cloud.header.frame_id.assign(frame_id);
+  cloud.height = 1;
+  cloud.width = 0;
+  cloud.fields.resize(6);
+  cloud.fields[0].offset = 0;
+  cloud.fields[0].name = "x";
+  cloud.fields[0].count = 1;
+  cloud.fields[0].datatype = PointField::FLOAT32;
+  cloud.fields[1].offset = 4;
+  cloud.fields[1].name = "y";
+  cloud.fields[1].count = 1;
+  cloud.fields[1].datatype = PointField::FLOAT32;
+  cloud.fields[2].offset = 8;
+  cloud.fields[2].name = "z";
+  cloud.fields[2].count = 1;
+  cloud.fields[2].datatype = PointField::FLOAT32;
+  cloud.fields[3].offset = 12;
+  cloud.fields[3].name = "range";
+  cloud.fields[3].count = 1;
+  cloud.fields[3].datatype = PointField::FLOAT32;
+  cloud.fields[4].offset = 16;
+  cloud.fields[4].name = "thetha";
+  cloud.fields[4].count = 1;
+  cloud.fields[4].datatype = PointField::FLOAT32;
+  cloud.fields[5].offset = 20;
+  cloud.fields[5].name = "phi";
+  cloud.fields[5].count = 1;
+  cloud.fields[5].datatype = PointField::FLOAT32;
+  cloud.point_step = sizeof(LivoxPointRtp);
+}
+
+void Lddc::PublishPointcloud2InvalidPointsData(const uint8_t index, const uint64_t timestamp, const PointCloud2& cloud) {
+#ifdef BUILDING_ROS1
+  PublisherPtr publisher_ptr = Lddc::GetCurrentInvalidPointsPublisher(index);
+#elif defined BUILDING_ROS2
+  Publisher<PointCloud2>::SharedPtr publisher_ptr =
+    std::dynamic_pointer_cast<Publisher<PointCloud2>>(GetCurrentInvalidPointsPublisher(index));
+#endif
+
+  if (kOutputToRos == output_type_) {
+    publisher_ptr->publish(cloud);
+  } else {
+#ifdef BUILDING_ROS1
+    if (bag_ && enable_lidar_bag_) {
+      bag_->write(publisher_ptr->getTopic(), ros::Time(timestamp / 1000000000.0), cloud);
+    }
+#endif
+  }
+}
+
 void Lddc::PublishPointcloud2Data(const uint8_t index, const uint64_t timestamp, const PointCloud2& cloud) {
 #ifdef BUILDING_ROS1
   PublisherPtr publisher_ptr = Lddc::GetCurrentPublisher(index);
@@ -503,7 +610,7 @@ void Lddc::InitCustomMsg(CustomMsg& livox_msg, const StoragePacket& pkg, uint8_t
 
 void Lddc::FillPointsToCustomMsg(CustomMsg& livox_msg, const StoragePacket& pkg) {
   uint32_t points_num = pkg.points_num;
-  const std::vector<PointXyzlt>& points = pkg.points;
+  const std::vector<PointXyzltrtp>& points = pkg.points;
   for (uint32_t i = 0; i < points_num; ++i) {
     CustomPoint point;
     point.x = points[i].x;
@@ -512,6 +619,7 @@ void Lddc::FillPointsToCustomMsg(CustomMsg& livox_msg, const StoragePacket& pkg)
     point.reflectivity = points[i].intensity;
     point.tag = points[i].tag;
     point.line = points[i].line;
+    //point.range = sqrt(points[i].x * points[i].x + points[i].y * points[i].y + points[i].z * points[i].z);
     point.offset_time = static_cast<uint32_t>(points[i].offset_time - pkg.base_time);
 
     livox_msg.points.push_back(std::move(point));
@@ -561,7 +669,7 @@ void Lddc::FillPointsToPclMsg(const StoragePacket& pkg, PointCloud& pcl_msg) {
   }
 
   uint32_t points_num = pkg.points_num;
-  const std::vector<PointXyzlt>& points = pkg.points;
+  const std::vector<PointXyzltrtp>& points = pkg.points;
   for (uint32_t i = 0; i < points_num; ++i) {
     pcl::PointXYZI point;
     point.x = points[i].x;
@@ -775,6 +883,41 @@ PublisherPtr Lddc::GetCurrentImuPublisher(uint8_t handle) {
 
   return *pub;
 }
+
+PublisherPtr Lddc::GetCurrentInvalidPointsPublisher(uint8_t handle) {
+  ros::Publisher **pub = nullptr;
+  uint32_t queue_size = kMinEthPacketQueueSize;
+
+  if (use_multi_topic_) {
+    pub = &private_invalid_points_pub_[handle];
+    queue_size = queue_size * 2; // queue size is 64 for only one lidar
+  } else {
+    pub = &global_invalid_points_pub_;
+    queue_size = queue_size * 8; // shared queue size is 256, for all lidars
+  }
+
+  if (*pub == nullptr) {
+    char name_str[48];
+    memset(name_str, 0, sizeof(name_str));
+    if (use_multi_topic_) {
+      DRIVER_INFO(*cur_node_, "Support multi topics.");
+      std::string ip_string = IpNumToString(lds_->lidars_[handle].handle);
+      snprintf(name_str, sizeof(name_str), "livox/invalid_points_%s",
+               ReplacePeriodByUnderline(ip_string).c_str());
+    } else {
+      DRIVER_INFO(*cur_node_, "Support only one topic.");
+      snprintf(name_str, sizeof(name_str), "livox/invalid_points");
+    }
+
+    *pub = new ros::Publisher;
+    **pub = cur_node_->GetNode().advertise<sensor_msgs::PointCloud2>(name_str, queue_size);
+    DRIVER_INFO(*cur_node_, "%s publish invalid point data, set ROS publisher queue size %d", name_str,
+             queue_size);
+  }
+
+  return *pub;
+}
+
 #elif defined BUILDING_ROS2
 std::shared_ptr<rclcpp::PublisherBase> Lddc::GetCurrentPublisher(uint8_t handle) {
   uint32_t queue_size = kMinEthPacketQueueSize;

--- a/src/lddc.cpp
+++ b/src/lddc.cpp
@@ -300,7 +300,7 @@ void Lddc::PublishPointcloud2(LidarDataQueue *queue, uint8_t index, const std::s
     {
       sensor_msgs::PointCloud2 invalid_points_cloud;
       //printf("Publish invalid points.\n");
-      printf("Points in pkg: %u", pkg.points.size());
+      //printf("Points in pkg: %u", pkg.points.size());
       InitPointcloud2InvalidPointsMsg(pkg, invalid_points_cloud, timestamp, frame_id);
       PublishPointcloud2InvalidPointsData(index, timestamp, invalid_points_cloud);  
     }
@@ -498,10 +498,11 @@ void Lddc::InitPointcloud2InvalidPointsMsg(const StoragePacket& pkg, PointCloud2
       point.range = pkg.points[i].range;
       point.thetha = pkg.points[i].theta;
       point.phi = pkg.points[i].phi;
+      point.tag = pkg.points[i].tag;
       points.push_back(std::move(point));
     }
   }
-  printf("Points %u\n", points.size());
+  //printf("Points %u\n", points.size());
   cloud.width = points.size();
   cloud.row_step = cloud.width * cloud.point_step;
   cloud.data.resize(points.size() * sizeof(LivoxPointRtp));
@@ -512,7 +513,7 @@ void Lddc::InitPointcloud2InvalidPointsMsgHeader(PointCloud2& cloud, const std::
   cloud.header.frame_id.assign(frame_id);
   cloud.height = 1;
   cloud.width = 0;
-  cloud.fields.resize(6);
+  cloud.fields.resize(7);
   cloud.fields[0].offset = 0;
   cloud.fields[0].name = "x";
   cloud.fields[0].count = 1;
@@ -537,6 +538,10 @@ void Lddc::InitPointcloud2InvalidPointsMsgHeader(PointCloud2& cloud, const std::
   cloud.fields[5].name = "phi";
   cloud.fields[5].count = 1;
   cloud.fields[5].datatype = PointField::FLOAT32;
+  cloud.fields[6].offset = 24;
+  cloud.fields[6].name = "tag";
+  cloud.fields[6].count = 1;
+  cloud.fields[6].datatype = PointField::UINT8;
   cloud.point_step = sizeof(LivoxPointRtp);
 }
 

--- a/src/lddc.h
+++ b/src/lddc.h
@@ -79,7 +79,7 @@ class Lddc final {
 #ifdef BUILDING_ROS1
   Lddc(int format, int multi_topic, int data_src, int output_type, double frq, std::string &frame_id,
        const std::vector<double>& angular_velocity_covariance,
-       const std::vector<double>& linear_acceleration_covariance, bool lidar_bag, bool imu_bag, bool dust_filter, bool pub_invalid_points);
+       const std::vector<double>& linear_acceleration_covariance, bool lidar_bag, bool imu_bag, bool dust_filter, bool pub_non_return_rays);
 #elif defined BUILDING_ROS2
   Lddc(int format, int multi_topic, int data_src, int output_type, double frq,
       std::string &frame_id);
@@ -116,9 +116,9 @@ class Lddc final {
   void InitPointcloud2Msg(const StoragePacket& pkg, PointCloud2& cloud, uint64_t& timestamp, const std::string& frame_id);
   void PublishPointcloud2Data(const uint8_t index, uint64_t timestamp, const PointCloud2& cloud);
 
-  void InitPointcloud2InvalidPointsMsgHeader(PointCloud2& cloud, const std::string& frame_id);
-  void InitPointcloud2InvalidPointsMsg(const StoragePacket& pkg, PointCloud2& cloud, uint64_t& timestamp, const std::string& frame_id);
-  void PublishPointcloud2InvalidPointsData(const uint8_t index, uint64_t timestamp, const PointCloud2& cloud);
+  void InitPointcloud2NonReturnRaysMsgHeader(PointCloud2& cloud, const std::string& frame_id);
+  void InitPointcloud2NonReturnRaysMsg(const StoragePacket& pkg, PointCloud2& cloud, uint64_t& timestamp, const std::string& frame_id);
+  void PublishPointcloud2NonReturnRaysData(const uint8_t index, uint64_t timestamp, const PointCloud2& cloud);
 
   void InitCustomMsg(CustomMsg& livox_msg, const StoragePacket& pkg, uint8_t index, const std::string& frame_id);
   void FillPointsToCustomMsg(CustomMsg& livox_msg, const StoragePacket& pkg);
@@ -140,7 +140,7 @@ class Lddc final {
 
   PublisherPtr GetCurrentPublisher(uint8_t index);
   PublisherPtr GetCurrentImuPublisher(uint8_t index);
-  PublisherPtr GetCurrentInvalidPointsPublisher(uint8_t index);
+  PublisherPtr GetCurrentNonReturnRaysPublisher(uint8_t index);
 
  private:
   uint8_t transfer_format_;
@@ -156,14 +156,14 @@ class Lddc final {
 #ifdef BUILDING_ROS1
   bool enable_lidar_bag_;
   bool enable_imu_bag_;
-  bool pub_invalid_points_;
+  bool pub_non_return_rays_;
   std::optional<std::vector<dust_filter_livox::DustFilter<livox_ros::PCLLivoxPointXyzrtlt>>> dust_filters_;
   PublisherPtr private_pub_[kMaxSourceLidar];
   PublisherPtr global_pub_;
   PublisherPtr private_imu_pub_[kMaxSourceLidar];
   PublisherPtr global_imu_pub_;
-  PublisherPtr private_invalid_points_pub_[kMaxSourceLidar];
-  PublisherPtr global_invalid_points_pub_;
+  PublisherPtr private_non_return_rays_pub_[kMaxSourceLidar];
+  PublisherPtr global_non_return_rays_pub_;
   rosbag::Bag *bag_;
 
 #elif defined BUILDING_ROS2

--- a/src/lddc.h
+++ b/src/lddc.h
@@ -79,7 +79,7 @@ class Lddc final {
 #ifdef BUILDING_ROS1
   Lddc(int format, int multi_topic, int data_src, int output_type, double frq, std::string &frame_id,
        const std::vector<double>& angular_velocity_covariance,
-       const std::vector<double>& linear_acceleration_covariance, bool lidar_bag, bool imu_bag, bool dust_filter);
+       const std::vector<double>& linear_acceleration_covariance, bool lidar_bag, bool imu_bag, bool dust_filter, bool pub_invalid_points);
 #elif defined BUILDING_ROS2
   Lddc(int format, int multi_topic, int data_src, int output_type, double frq,
       std::string &frame_id);
@@ -116,6 +116,10 @@ class Lddc final {
   void InitPointcloud2Msg(const StoragePacket& pkg, PointCloud2& cloud, uint64_t& timestamp, const std::string& frame_id);
   void PublishPointcloud2Data(const uint8_t index, uint64_t timestamp, const PointCloud2& cloud);
 
+  void InitPointcloud2InvalidPointsMsgHeader(PointCloud2& cloud, const std::string& frame_id);
+  void InitPointcloud2InvalidPointsMsg(const StoragePacket& pkg, PointCloud2& cloud, uint64_t& timestamp, const std::string& frame_id);
+  void PublishPointcloud2InvalidPointsData(const uint8_t index, uint64_t timestamp, const PointCloud2& cloud);
+
   void InitCustomMsg(CustomMsg& livox_msg, const StoragePacket& pkg, uint8_t index, const std::string& frame_id);
   void FillPointsToCustomMsg(CustomMsg& livox_msg, const StoragePacket& pkg);
   void PublishCustomPointData(const CustomMsg& livox_msg, const uint8_t index);
@@ -136,6 +140,7 @@ class Lddc final {
 
   PublisherPtr GetCurrentPublisher(uint8_t index);
   PublisherPtr GetCurrentImuPublisher(uint8_t index);
+  PublisherPtr GetCurrentInvalidPointsPublisher(uint8_t index);
 
  private:
   uint8_t transfer_format_;
@@ -151,11 +156,14 @@ class Lddc final {
 #ifdef BUILDING_ROS1
   bool enable_lidar_bag_;
   bool enable_imu_bag_;
+  bool pub_invalid_points_;
   std::optional<std::vector<dust_filter_livox::DustFilter<livox_ros::PCLLivoxPointXyzrtlt>>> dust_filters_;
   PublisherPtr private_pub_[kMaxSourceLidar];
   PublisherPtr global_pub_;
   PublisherPtr private_imu_pub_[kMaxSourceLidar];
   PublisherPtr global_imu_pub_;
+  PublisherPtr private_invalid_points_pub_[kMaxSourceLidar];
+  PublisherPtr global_invalid_points_pub_;
   rosbag::Bag *bag_;
 
 #elif defined BUILDING_ROS2

--- a/src/lds_lidar.cpp
+++ b/src/lds_lidar.cpp
@@ -274,7 +274,7 @@ std::optional<std::tuple<float, float, float>> LdsLidar::GetTransformation(const
   constexpr double transform_timeout {1.0};
   if(!buffer_.canTransform(target_frame, source_frame, ros::Time(0), ros::Duration(transform_timeout)))
   {
-    std::cout << "Timout wait for Transformation" << std::endl;
+    std::cout << "Timout wait for Transformation:" << target_frame << " " << source_frame << std::endl;
     return std::nullopt;
   }
 

--- a/src/lds_lidar.cpp
+++ b/src/lds_lidar.cpp
@@ -228,7 +228,7 @@ bool LdsLidar::InitLivoxLidar() {
       }
       else
       {
-        throw std::runtime_error("Failed to lookup transformation between " + config.frame_id + " and " + config.filter_param.filter_frame_id);
+        throw std::runtime_error("Failed to lookup transformation between " + config.frame_id + " and " + config.filter_rays_param.filter_rays_frame_id);
       }
     }
 

--- a/src/lds_lidar.cpp
+++ b/src/lds_lidar.cpp
@@ -208,6 +208,31 @@ bool LdsLidar::InitLivoxLidar() {
         throw std::runtime_error("Failed to lookup transformation between " + config.frame_id + " and " + config.filter_param.filter_frame_id);
       }
     }
+
+    if (config.enable_rays_filter) {
+      LidarFilterRaysParameter rays_param;
+      rays_param.handle = config.handle;
+      rays_param.lidar_type = kLivoxLidarType;
+      rays_param.rays_param = config.filter_rays_param;
+      // Do I need these next lines? should be already copied from the line before?
+      rays_param.rays_param.filter_rays_yaw_start = config.filter_rays_param.filter_rays_yaw_start;
+      rays_param.rays_param.filter_rays_yaw_end = config.filter_rays_param.filter_rays_yaw_end;
+      rays_param.rays_param.filter_rays_pitch_start = config.filter_rays_param.filter_rays_pitch_start;
+      rays_param.rays_param.filter_rays_pitch_end = config.filter_rays_param.filter_rays_pitch_end;
+      auto rotation = GetTransformation(config.filter_rays_param.filter_rays_frame_id, config.frame_id);
+      if (rotation)
+      {
+        rays_param.transform.roll = std::get<0>(*rotation);
+        rays_param.transform.pitch = std::get<1>(*rotation);
+        rays_param.transform.yaw = std::get<2>(*rotation);
+        pub_handler().AddLidarsFilterRaysParam(rays_param);
+      }
+      else
+      {
+        throw std::runtime_error("Failed to lookup transformation between " + config.frame_id + " and " + config.filter_param.filter_frame_id);
+      }
+    }
+
   }
 
   SetLivoxLidarInfoChangeCallback(LivoxLidarCallback::LidarInfoChangeCallback, g_lds_ldiar);

--- a/src/lds_lidar.cpp
+++ b/src/lds_lidar.cpp
@@ -214,7 +214,6 @@ bool LdsLidar::InitLivoxLidar() {
       rays_param.handle = config.handle;
       rays_param.lidar_type = kLivoxLidarType;
       rays_param.rays_param = config.filter_rays_param;
-      // Do I need these next lines? should be already copied from the line before?
       rays_param.rays_param.filter_rays_yaw_start = config.filter_rays_param.filter_rays_yaw_start;
       rays_param.rays_param.filter_rays_yaw_end = config.filter_rays_param.filter_rays_yaw_end;
       rays_param.rays_param.filter_rays_pitch_start = config.filter_rays_param.filter_rays_pitch_start;

--- a/src/livox_ros_driver2.cpp
+++ b/src/livox_ros_driver2.cpp
@@ -61,10 +61,9 @@ int main(int argc, char **argv) {
   bool lidar_bag = true;
   bool imu_bag   = false;
   bool dust_filter = false;
+  bool publish_non_return_rays = false;
   std::vector<double> angular_velocity_covariance;
   std::vector<double> linear_acceleration_covariance;
-
-  bool pub_invalid_points = false;
   nh.getParam("xfer_format", xfer_format);
   nh.getParam("multi_topic", multi_topic);
   nh.getParam("data_src", data_src);
@@ -76,7 +75,7 @@ int main(int argc, char **argv) {
   nh.getParam("enable_lidar_bag", lidar_bag);
   nh.getParam("enable_imu_bag", imu_bag);
   nh.getParam("enable_dust_filter", dust_filter);
-  nh.getParam("publish_invalid_points", pub_invalid_points);
+  nh.getParam("publish_non_return_rays", publish_non_return_rays);
   printf("data source:%u.\n", data_src);
 
   if (publish_freq > 100.0) {
@@ -92,7 +91,7 @@ int main(int argc, char **argv) {
   /** Lidar data distribute control and lidar data source set */
   livox_node.lddc_ptr_ = std::make_unique<Lddc>(xfer_format, multi_topic, data_src, output_type, publish_freq, frame_id,
                                                 angular_velocity_covariance, linear_acceleration_covariance,
-                                                lidar_bag, imu_bag, dust_filter, pub_invalid_points);
+                                                lidar_bag, imu_bag, dust_filter, publish_non_return_rays);
   livox_node.lddc_ptr_->SetRosNode(&livox_node);
 
   if (data_src == kSourceRawLidar) {

--- a/src/livox_ros_driver2.cpp
+++ b/src/livox_ros_driver2.cpp
@@ -64,6 +64,7 @@ int main(int argc, char **argv) {
   std::vector<double> angular_velocity_covariance;
   std::vector<double> linear_acceleration_covariance;
 
+  bool pub_invalid_points = false;
   nh.getParam("xfer_format", xfer_format);
   nh.getParam("multi_topic", multi_topic);
   nh.getParam("data_src", data_src);
@@ -75,6 +76,7 @@ int main(int argc, char **argv) {
   nh.getParam("enable_lidar_bag", lidar_bag);
   nh.getParam("enable_imu_bag", imu_bag);
   nh.getParam("enable_dust_filter", dust_filter);
+  nh.getParam("publish_invalid_points", pub_invalid_points);
   printf("data source:%u.\n", data_src);
 
   if (publish_freq > 100.0) {
@@ -90,7 +92,7 @@ int main(int argc, char **argv) {
   /** Lidar data distribute control and lidar data source set */
   livox_node.lddc_ptr_ = std::make_unique<Lddc>(xfer_format, multi_topic, data_src, output_type, publish_freq, frame_id,
                                                 angular_velocity_covariance, linear_acceleration_covariance,
-                                                lidar_bag, imu_bag, dust_filter);
+                                                lidar_bag, imu_bag, dust_filter, pub_invalid_points);
   livox_node.lddc_ptr_->SetRosNode(&livox_node);
 
   if (data_src == kSourceRawLidar) {

--- a/src/livox_ros_driver2.cpp
+++ b/src/livox_ros_driver2.cpp
@@ -64,6 +64,7 @@ int main(int argc, char **argv) {
   bool publish_non_return_rays = false;
   std::vector<double> angular_velocity_covariance;
   std::vector<double> linear_acceleration_covariance;
+
   nh.getParam("xfer_format", xfer_format);
   nh.getParam("multi_topic", multi_topic);
   nh.getParam("data_src", data_src);

--- a/src/nodelet.cpp
+++ b/src/nodelet.cpp
@@ -56,7 +56,7 @@ livox_ros::Nodelet::onInit()
   bool lidar_bag = true;
   bool imu_bag   = false;
   bool dust_filter = false;
-  bool pub_invalid_points = false;
+  bool publish_non_return_rays = false;
   std::vector<double> angular_velocity_covariance;
   std::vector<double> linear_acceleration_covariance;
 
@@ -71,7 +71,7 @@ livox_ros::Nodelet::onInit()
   nh.getParam("enable_lidar_bag", lidar_bag);
   nh.getParam("enable_imu_bag", imu_bag);
   nh.getParam("enable_dust_filter", dust_filter);
-  nh.getParam("publish_invalid_points", pub_invalid_points);
+  nh.getParam("publish_non_return_rays", publish_non_return_rays);
   if (publish_freq > 100.0) {
     publish_freq = 100.0;
   } else if (publish_freq < 0.5) {
@@ -85,7 +85,7 @@ livox_ros::Nodelet::onInit()
   /** Lidar data distribute control and lidar data source set */
   livox_node_->lddc_ptr_ = std::make_unique<Lddc>(xfer_format, multi_topic, data_src, output_type, publish_freq,
                                                   frame_id, angular_velocity_covariance, linear_acceleration_covariance,
-                                                  lidar_bag, imu_bag, dust_filter, pub_invalid_points);
+                                                  lidar_bag, imu_bag, dust_filter, publish_non_return_rays);
   livox_node_->lddc_ptr_->SetRosNode(livox_node_.get());
 
   if (data_src == kSourceRawLidar) {

--- a/src/nodelet.cpp
+++ b/src/nodelet.cpp
@@ -56,6 +56,7 @@ livox_ros::Nodelet::onInit()
   bool lidar_bag = true;
   bool imu_bag   = false;
   bool dust_filter = false;
+  bool pub_invalid_points = false;
   std::vector<double> angular_velocity_covariance;
   std::vector<double> linear_acceleration_covariance;
 
@@ -70,7 +71,7 @@ livox_ros::Nodelet::onInit()
   nh.getParam("enable_lidar_bag", lidar_bag);
   nh.getParam("enable_imu_bag", imu_bag);
   nh.getParam("enable_dust_filter", dust_filter);
-
+  nh.getParam("publish_invalid_points", pub_invalid_points);
   if (publish_freq > 100.0) {
     publish_freq = 100.0;
   } else if (publish_freq < 0.5) {
@@ -84,7 +85,7 @@ livox_ros::Nodelet::onInit()
   /** Lidar data distribute control and lidar data source set */
   livox_node_->lddc_ptr_ = std::make_unique<Lddc>(xfer_format, multi_topic, data_src, output_type, publish_freq,
                                                   frame_id, angular_velocity_covariance, linear_acceleration_covariance,
-                                                  lidar_bag, imu_bag, dust_filter);
+                                                  lidar_bag, imu_bag, dust_filter, pub_invalid_points);
   livox_node_->lddc_ptr_->SetRosNode(livox_node_.get());
 
   if (data_src == kSourceRawLidar) {

--- a/src/parse_cfg_file/parse_livox_lidar_cfg.cpp
+++ b/src/parse_cfg_file/parse_livox_lidar_cfg.cpp
@@ -249,7 +249,7 @@ bool LivoxLidarConfigParser::ParseFilterRaysParameters(const rapidjson::Value &v
   if (!value.HasMember("filter_rays_local_theta")) {
     param.filter_rays_local_theta = false;
   } else {
-    param.filter_rays_local_theta = true;
+    param.filter_rays_local_theta = value["filter_rays_local_theta"].GetBool();
     if (!value.HasMember("filter_rays_local_theta_start")) {
       param.filter_rays_local_theta_start = 0.0f;
     } else {

--- a/src/parse_cfg_file/parse_livox_lidar_cfg.cpp
+++ b/src/parse_cfg_file/parse_livox_lidar_cfg.cpp
@@ -246,6 +246,21 @@ bool LivoxLidarConfigParser::ParseFilterRaysParameters(const rapidjson::Value &v
   } else {
     param.filter_rays_pitch_end = static_cast<float>(value["filter_rays_pitch_end"].GetFloat());
   }
+  if (!value.HasMember("filter_rays_local_theta")) {
+    param.filter_rays_local_theta = false;
+  } else {
+    param.filter_rays_local_theta = true;
+    if (!value.HasMember("filter_rays_local_theta_start")) {
+      param.filter_rays_local_theta_start = 0.0f;
+    } else {
+      param.filter_rays_local_theta_start = static_cast<float>(value["filter_rays_local_theta_start"].GetFloat());
+    }
+    if (!value.HasMember("filter_rays_local_theta_end")) {
+      param.filter_rays_local_theta_end = 0.0f;
+    } else {
+      param.filter_rays_local_theta_end = static_cast<float>(value["filter_rays_local_theta_end"].GetFloat());
+    }
+  }
   return true;
 }
 } // namespace livox_ros

--- a/src/parse_cfg_file/parse_livox_lidar_cfg.cpp
+++ b/src/parse_cfg_file/parse_livox_lidar_cfg.cpp
@@ -130,6 +130,22 @@ bool LivoxLidarConfigParser::ParseUserConfigs(const rapidjson::Document &doc,
         return false;
       }
     }
+
+    if (!config.HasMember("enable_rays_filter")) {
+      user_config.enable_rays_filter = false;
+    } else {
+      user_config.enable_rays_filter = static_cast<bool>(config["enable_rays_filter"].GetBool());
+    }
+    if (!config.HasMember("filter_rays_parameter") || !user_config.enable_rays_filter) {
+      user_config.filter_rays_param = FilterRaysParameter{};
+    } else {
+      auto &value = config["filter_rays_parameter"];
+      if (!ParseFilterRaysParameters(value, user_config.filter_rays_param)) {
+        user_config.filter_rays_param = FilterRaysParameter{};
+        std::cout << "failed to parse filter rays parameters, ip: "
+                  << IpNumToString(user_config.handle) << std::endl;
+      }
+    }
     user_config.set_bits = 0;
     user_config.get_bits = 0;
 
@@ -198,6 +214,37 @@ bool LivoxLidarConfigParser::ParseFilterParameters(const rapidjson::Value &value
     param.filter_yaw_end = 360.0f;
   } else {
     param.filter_yaw_end = static_cast<float>(value["filter_yaw_end"].GetFloat());
+  }
+  return true;
+}
+
+bool LivoxLidarConfigParser::ParseFilterRaysParameters(const rapidjson::Value &value,
+                                                       FilterRaysParameter &param) {
+
+  if (!value.HasMember("filter_rays_frame_id")) {
+    param.filter_rays_frame_id = "";
+  } else {
+    param.filter_rays_frame_id = static_cast<std::string>(value["filter_rays_frame_id"].GetString());
+  }
+  if (!value.HasMember("filter_rays_yaw_start")) {
+    param.filter_rays_yaw_start = 0.0f;
+  } else {
+    param.filter_rays_yaw_start = static_cast<float>(value["filter_rays_yaw_start"].GetFloat());
+  }
+  if (!value.HasMember("filter_rays_yaw_end")) {
+    param.filter_rays_yaw_end = 360.0f;
+  } else {
+    param.filter_rays_yaw_end = static_cast<float>(value["filter_rays_yaw_end"].GetFloat());
+  }
+  if (!value.HasMember("filter_rays_pitch_start")) {
+    param.filter_rays_pitch_start = 0.0f;
+  } else {
+    param.filter_rays_pitch_start = static_cast<float>(value["filter_rays_pitch_start"].GetFloat());
+  }
+  if (!value.HasMember("filter_rays_pitch_end")) {
+    param.filter_rays_pitch_end = 360.0f;
+  } else {
+    param.filter_rays_pitch_end = static_cast<float>(value["filter_rays_pitch_end"].GetFloat());
   }
   return true;
 }

--- a/src/parse_cfg_file/parse_livox_lidar_cfg.h
+++ b/src/parse_cfg_file/parse_livox_lidar_cfg.h
@@ -50,6 +50,8 @@ class LivoxLidarConfigParser {
                          std::vector<UserLivoxLidarConfig> &user_configs);
   bool ParseExtrinsics(const rapidjson::Value &value, ExtParameter &param);
   bool ParseFilterParameters(const rapidjson::Value &value, FilterParameter &param);
+  bool ParseFilterRaysParameters(const rapidjson::Value &value, FilterRaysParameter &param);
+
   const std::string path_;
 };
 


### PR DESCRIPTION
This PR adds a publisher for all rays without a return. It only works, if the `pcl_data_type` is set to spherical (3).
Test together with PR in main repo.