### PR TITLE
Bump livox_sdk to work with Ubuntu noble 24.04

### DIFF
--- a/launch_ROS2/msg_MID360_launch.py
+++ b/launch_ROS2/msg_MID360_launch.py
@@ -14,6 +14,7 @@ frame_id      = 'livox_frame'
 lvx_file_path = '/home/livox/livox_test.lvx'
 cmdline_bd_code = 'livox0000000001'
 enable_dust_filter = True
+publish_non_return_rays = True
 
 cur_path = os.path.split(os.path.realpath(__file__))[0] + '/'
 cur_config_path = cur_path + '../config'
@@ -30,7 +31,8 @@ livox_ros2_params = [
     {"lvx_file_path": lvx_file_path},
     {"user_config_path": user_config_path},
     {"cmdline_input_bd_code": cmdline_bd_code},
-    {"enable_dust_filter": enable_dust_filter}
+    {"enable_dust_filter": enable_dust_filter},
+    {"publish_non_return_rays": publish_non_return_rays}
 ]
 
 

--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,7 @@
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
+  <depend>rapidjson-dev</depend>
 
   <exec_depend>rosbag2</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>

--- a/src/lddc.cpp
+++ b/src/lddc.cpp
@@ -41,9 +41,12 @@
 #include "lds_lidar.h"
 
 #include <pcl_conversions/pcl_conversions.h>
+#include <rmw/qos_profiles.h>
 
 #include <enway_msgs/msg/error_array.hpp>
 #include <enway_msgs/msg/error_generic.hpp>
+
+
 
 namespace livox_ros
 {
@@ -947,8 +950,8 @@ std::shared_ptr<rclcpp::PublisherBase> Lddc::CreatePublisher(uint8_t msg_type,
     std::string &topic_name, uint32_t queue_size) {
     if (kPointCloud2Msg == msg_type) {
       DRIVER_INFO(*cur_node_,
-          "%s publish use PointCloud2 format", topic_name.c_str());
-      return cur_node_->create_publisher<PointCloud2>(topic_name, queue_size);
+          "%s publish use PointCloud2 format with sensor QoS", topic_name.c_str());
+      return cur_node_->create_publisher<PointCloud2>(topic_name, rclcpp::SensorDataQoS());
     } else if (kLivoxCustomMsg == msg_type) {
       DRIVER_INFO(*cur_node_,
           "%s publish use livox custom format", topic_name.c_str());

--- a/src/lddc.cpp
+++ b/src/lddc.cpp
@@ -101,7 +101,7 @@ Lddc::Lddc(int format, int multi_topic, int data_src, int output_type, double fr
 #elif defined BUILDING_ROS2
 Lddc::Lddc(int format, int multi_topic, int data_src, int output_type, double frq, std::string& frame_id, 
            const std::vector<double>& angular_velocity_covariance,
-           const std::vector<double>& linear_acceleration_covariance, bool dust_filter)
+           const std::vector<double>& linear_acceleration_covariance, bool dust_filter, bool pub_non_return_rays)
   : transfer_format_(format)
   , use_multi_topic_(multi_topic)
   , data_src_(data_src)
@@ -110,6 +110,7 @@ Lddc::Lddc(int format, int multi_topic, int data_src, int output_type, double fr
   , frame_id_(frame_id)
   , angular_velocity_covariance_(angular_velocity_covariance)
   , linear_acceleration_covariance_(linear_acceleration_covariance)
+  , pub_non_return_rays_(pub_non_return_rays)
 {
   std::cout << "Transfer format: " << format << std::endl;
   publish_period_ns_ = kNsPerSecond / publish_frq_;
@@ -1094,8 +1095,7 @@ PublisherPtr Lddc::GetCurrentErrorPublisher(uint8_t handle) {
 
     *pub = new ros::Publisher;
     **pub = cur_node_->GetNode().advertise<enway_msgs::ErrorArray>(name_str, queue_size);
-    DRIVER_INFO(*cur_node_, "%s publish error data, set ROS publisher queue size %d", name_str,
-             queue_size);
+    DRIVER_INFO(*cur_node_, "%s publish error data, set ROS publisher queue size %d", name_str, queue_size);
   }
 
   return *pub;

--- a/src/lddc.h
+++ b/src/lddc.h
@@ -98,7 +98,7 @@ class Lddc final {
 #elif defined BUILDING_ROS2
   Lddc(int format, int multi_topic, int data_src, int output_type, double frq, std::string &frame_id,
        const std::vector<double>& angular_velocity_covariance,
-       const std::vector<double>& linear_acceleration_covariance, bool dust_filter);
+       const std::vector<double>& linear_acceleration_covariance, bool dust_filter, bool pub_non_return_rays);
 #endif
   ~Lddc();
 

--- a/src/lds_lidar.cpp
+++ b/src/lds_lidar.cpp
@@ -165,12 +165,6 @@ bool LdsLidar::InitLivoxLidar(rclcpp::Clock::SharedPtr ros_clock) {
     return false;
   }
 
-  // SDK initialization
-  if (!LivoxLidarSdkInit(path_.c_str())) {
-    std::cout << "Failed to init livox lidar sdk." << std::endl;
-    return false;
-  }
-
   // fill in lidar devices
   for (auto& config : user_configs) {
     uint8_t index = 0;
@@ -261,7 +255,12 @@ bool LdsLidar::InitLivoxLidar(rclcpp::Clock::SharedPtr ros_clock) {
         throw std::runtime_error("Failed to lookup transformation between " + config.frame_id + " and " + config.filter_rays_param.filter_rays_frame_id);
       }
     }
+  }
 
+  // SDK initialization
+  if (!LivoxLidarSdkInit(path_.c_str())) {
+    std::cout << "Failed to init livox lidar sdk." << std::endl;
+    return false;
   }
 
   SetLivoxLidarInfoChangeCallback(LivoxLidarCallback::LidarInfoChangeCallback, g_lds_ldiar);
@@ -328,7 +327,7 @@ std::optional<std::tuple<float, float, float>> LdsLidar::GetTransformation(const
   tf2_ros::TransformListener listener_{buffer_};
 
   std::string suppressed_error_string;
-  constexpr double transform_timeout {2.0};
+  constexpr double transform_timeout {5.0};
   if(!buffer_.canTransform(target_frame, source_frame, rclcpp::Time(0), rclcpp::Duration::from_seconds(transform_timeout), &suppressed_error_string))
   {
     std::cout << "Timout wait for Transformation:" << target_frame << " " << source_frame << std::endl;

--- a/src/livox_ros_driver2.cpp
+++ b/src/livox_ros_driver2.cpp
@@ -146,6 +146,7 @@ DriverNode::DriverNode(const rclcpp::NodeOptions & node_options)
   int output_type = kOutputToRos;
   std::string frame_id;
   bool dust_filter = false;
+  bool publish_non_return_rays = false;
   std::vector<double> angular_velocity_covariance;
   std::vector<double> linear_acceleration_covariance;
 
@@ -161,6 +162,7 @@ DriverNode::DriverNode(const rclcpp::NodeOptions & node_options)
   this->declare_parameter("angular_velocity_covariance", std::vector<double>(9, -1));
   this->declare_parameter("linear_acceleration_covariance", std::vector<double>(9, -1));
   this->declare_parameter("enable_dust_filter", false);
+  this->declare_parameter("publish_non_return_rays", false);
 
   this->get_parameter("xfer_format", xfer_format);
   this->get_parameter("multi_topic", multi_topic);
@@ -171,7 +173,7 @@ DriverNode::DriverNode(const rclcpp::NodeOptions & node_options)
   this->get_parameter("angular_velocity_covariance", angular_velocity_covariance);
   this->get_parameter("linear_acceleration_covariance", linear_acceleration_covariance);
   this->get_parameter("enable_dust_filter", dust_filter);
-
+  this->get_parameter("publish_non_return_rays", publish_non_return_rays);
   if (publish_freq > 100.0) {
     publish_freq = 100.0;
   } else if (publish_freq < 0.5) {
@@ -184,7 +186,7 @@ DriverNode::DriverNode(const rclcpp::NodeOptions & node_options)
 
   /** Lidar data distribute control and lidar data source set */
   lddc_ptr_ = std::make_unique<Lddc>(xfer_format, multi_topic, data_src, output_type, publish_freq, frame_id, 
-                                     angular_velocity_covariance, linear_acceleration_covariance, dust_filter);
+                                     angular_velocity_covariance, linear_acceleration_covariance, dust_filter, publish_non_return_rays);
   lddc_ptr_->SetRosNode(this);
 
   if (data_src == kSourceRawLidar) {


### PR DESCRIPTION
- Ported non-return publisher to ROS 2
- Initialize livox_sdk after parsing the config (to avoid race conditions)
- Bump livox_sdk to newer version to work with noble

Attention:
Do not merge, before the livox_sdk PR is merged. https://github.com/enwaytech/Livox-SDK2/pull/3